### PR TITLE
Use upstream qless-core again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/qless/qless-core"]
 	path = lib/qless/qless-core
-	url = https://github.com/custora/qless-core.git
+	url = https://github.com/seomoz/qless-core.git


### PR DESCRIPTION
First step into reconciling with mainline qless. See https://github.com/custora/qless/pull/3 for why we created our own repo for qless-core. The changes we were adding there ahead of Moz are now merged into the mainline (https://github.com/seomoz/qless-core/pull/64). I tested qless on staging yesterday and ran jobs with seomoz/qless-core without issues.