### PR TITLE
Pivotal description character limit

### DIFF
--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -140,7 +140,7 @@
 
       data.name = `${siteId}: ${(job.history[job.history.length - 1] || {}).group || "Unknown Error"}`;
       data.description = `[Link to Job](${window.location.origin}/qless/jobs/${job.jid})\n\n` +
-        "`" + job.failure.message + "`";
+        "`" + job.failure.message.substring(0, 15000) + "`"; // keep well under 20k limit on description
       data.story_type = "bug";
       data.labels = ['bug', 'bugsnag'];
       return data;


### PR DESCRIPTION
Addendum to #4. This minor change helps keep the description field below Pivotal's 20k character limit.