### PR TITLE
Add new tag for import issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ MethodLength:
   Enabled: true
   Max: 40
 
+Metrics/LineLength:
+  Max: 140
+

--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -128,24 +128,21 @@ module Qless
       end
 
       def failed_jobs_by_type(include_tag: nil, exclude_tag: nil)
-        # include_tag and exclude_tag here work together, so that tagged returns all jobs that
-        # have the include tag but do not have the exclude_tag.
+        jobs = client.jobs.failed.map { |k, _v| [k, client.jobs.failed(k)['jobs']] }.to_h
 
-        jobs = client.jobs.failed.map { |k, v| [k, client.jobs.failed(k)["jobs"]] }.to_h
-        tagged = jobs.transform_values do |v|
+        find_tagged = jobs.transform_values do |v|
           v.select { |j| !j.tags.grep(include_tag).empty? && j.tags.grep(exclude_tag).empty? }
-        end.select { |_k, v| !v.empty? }
+        end
 
-        not_tagged = jobs.transform_values do |v|
-          ## select jobs where job.tags does not include the include_tag or where job.tags includes exclude tag
+        find_not_tagged = jobs.transform_values do |v|
           v.select do |job|
             job.tags.grep(include_tag).empty? || !job.tags.grep(exclude_tag).empty?
           end
-        end.select { |_k, v| !v.empty? }
+        end
 
         {
-          tagged: tagged,
-          not_tagged: not_tagged
+          tagged: find_tagged.reject { |_k, v| v.empty? },
+          not_tagged: find_not_tagged.reject { |_k, v| v.empty? }
         }
       end
 

--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -45,6 +45,8 @@
             <div class="btn-group custora-job-button-group">
               <% if (pt_tag = (job.tags || []).find { |tag| tag.match(/pt-(.*)/) }).nil? %>
                 <button title="Create Pivotal Story" class="btn btn-info" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
+              <% elsif (job.tags.find { |tag| tag.include?('auto-gen-pt')})%>
+                <button title="View Pivotal Story" class="btn btn-info" onclick="view_and_move_to_pt(<%=job.jid%>, <%= $1 %>)"><i class="glyphicon glyphicon-new-window"></i></button>
               <% else %>
                 <button title="View Pivotal Story" class="btn btn-info" onclick="window.open('https://www.pivotaltracker.com/story/show/<%= $1 %>', '_blank')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% end %>

--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -46,7 +46,7 @@
               <% if (pt_tag = (job.tags || []).find { |tag| tag.match(/pt-(.*)/) }).nil? %>
                 <button title="Create Pivotal Story" class="btn btn-info" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
               <% elsif (job.tags.find { |tag| tag.include?('auto-gen-pt')})%>
-                <button title="View Pivotal Story" class="btn btn-info" onclick="view_and_move_to_pt(<%=job.jid%>, <%= $1 %>)"><i class="glyphicon glyphicon-new-window"></i></button>
+                <button title="View Pivotal Story" class="btn btn-info" onclick="view_and_move_to_pt('<%=job.jid%>', '<%= $1 %>')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% else %>
                 <button title="View Pivotal Story" class="btn btn-info" onclick="window.open('https://www.pivotaltracker.com/story/show/<%= $1 %>', '_blank')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% end %>

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -268,9 +268,9 @@
       });
     }
 
-    var view_and_move_to_pt = function(jid, story_id) {
-      window.open('https://www.pivotaltracker.com/story/show/<%=story_id%>', '_blank')
-      job.untag(jid, 'auto-gen-pt')
+    var view_and_move_to_pt = function(jid, storyId) {
+      window.open('https://www.pivotaltracker.com/story/show/<%=storyId%>', '_blank');
+      untag(jid, 'auto-gen-pt');
     }
 
     /* Helper function for adding a tag to a job */

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -133,10 +133,6 @@
       });
     }
 
-    var addExistingPivotalStoryTag = function (jid, id) {
-      tag(jid, "pt-" + id)
-    }
-
     var jobToStory = function(job) {
       var data = {};
 

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -133,6 +133,10 @@
       });
     }
 
+    var addExistingPivotalStoryTag = function (jid, id) {
+      tag(jid, "pt-" + id)
+    }
+
     var jobToStory = function(job) {
       var data = {};
 
@@ -266,6 +270,11 @@
         });
         action();
       });
+    }
+
+    var view_and_move_to_pt = function(jid, story_id) {
+      window.open('https://www.pivotaltracker.com/story/show/<%=story_id%>', '_blank')
+      job.untag(jid, 'auto-gen-pt')
     }
 
     /* Helper function for adding a tag to a job */

--- a/lib/qless/server/views/overview.erb
+++ b/lib/qless/server/views/overview.erb
@@ -62,7 +62,7 @@
 </table>
 <% end %>
 
-<% failed_jobs = failed_jobs_by_type(tagged: /^pt-/) %>
+<% failed_jobs = failed_jobs_by_type(include_tag: /^pt-/, exclude_tag: 'auto-gen-pt']) %>
 <% failed_not_in_pt = failed_jobs[:not_tagged] %>
 <% failed_in_pt = failed_jobs[:tagged] %>
 


### PR DESCRIPTION
- Add functionality around a new tag 'auto-gen-pt
- If a job has a tag starting with 'pt-' but also this tag, then it will not show up in the in-pivotal section of qless
- This is so that you can navigate to the story in pivotal through qless for errors that have an auto-generated story without having them move to the 'in-pivotal' section, so that these errors don't get ignored.