### PR TITLE
Remove auto-gen-pt tag handling

### DIFF
--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -127,9 +127,9 @@ module Qless
         client.jobs.failed
       end
 
-      def failed_jobs_by_type(include_tag: nil, exclude_tag: nil)
+      def failed_jobs_by_type(include_tag: nil)
         jobs = client.jobs.failed.map { |k, _v| [k, client.jobs.failed(k)['jobs']] }.to_h
-        tag_filter = lambda { |j| !j.tags.grep(include_tag).empty? && j.tags.grep(exclude_tag).empty? }
+        tag_filter = lambda { |j| !j.tags.grep(include_tag).empty? }
 
         {
           tagged: jobs.transform_values { |v| v.select(&tag_filter) }.reject { |_k, v| v.empty? },

--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -45,8 +45,6 @@
             <div class="btn-group custora-job-button-group">
               <% if (pt_tag = (job.tags || []).find { |tag| tag.match(/pt-(.*)/) }).nil? %>
                 <button title="Create Pivotal Story" class="btn btn-info" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
-              <% elsif (job.tags.find { |tag| tag.include?('auto-gen-pt')})%>
-                <button title="View Pivotal Story" class="btn btn-info" onclick="view_and_move_to_pt('<%=job.jid%>', '<%= $1 %>')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% else %>
                 <button title="View Pivotal Story" class="btn btn-info" onclick="window.open('https://www.pivotaltracker.com/story/show/<%= $1 %>', '_blank')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% end %>

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -271,7 +271,6 @@
 
     var view_and_move_to_pt = function(jid, storyId) {
       window.open('https://www.pivotaltracker.com/story/show/' + storyId, '_blank');
-      untag(jid, 'auto-gen-pt');
     }
 
     /* Helper function for adding a tag to a job */

--- a/lib/qless/server/views/overview.erb
+++ b/lib/qless/server/views/overview.erb
@@ -62,7 +62,7 @@
 </table>
 <% end %>
 
-<% failed_jobs = failed_jobs_by_type(include_tag: /^pt-/, exclude_tag: 'auto-gen-pt') %>
+<% failed_jobs = failed_jobs_by_type(include_tag: /^pt-/) %>
 <% failed_not_in_pt = failed_jobs[:not_tagged] %>
 <% failed_in_pt = failed_jobs[:tagged] %>
 


### PR DESCRIPTION
This was added to force awareness of newly created tickets, but with the
current show-tix workflow this is no longer necessary, and in fact gets
in one's way a little as things stay in the top "Not in Pivotal" section
which drowns out actual bugs that haven't been dealt with yet.