### PR TITLE
Fix error when creating a Tracker story for the last failure of a type

### DIFF
--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -248,7 +248,7 @@ module Qless
 
       failed_jobs = if ['tagged', 'not_tagged'].include?(params[:pt])
         pivotal_label = params[:pt] == 'tagged' ? "(In Pivotal)" : "(Not In Pivotal)"
-        jobs = failed_jobs_by_type(include_tag: /^pt-/)[params[:pt].to_sym][params[:type]]
+        jobs = failed_jobs_by_type(include_tag: /^pt-/)[params[:pt].to_sym][params[:type]] || []
         {
           "jobs" => jobs,
           "total" => jobs.count,


### PR DESCRIPTION
The `failed_jobs_by_type` no longer contains the error group keys if
there are no more tagged/untagged errors of that type, so we need to
default to an empty list here.