### PR TITLE
Protect against ENOENT

### DIFF
--- a/lib/qless/failure_formatter.rb
+++ b/lib/qless/failure_formatter.rb
@@ -11,7 +11,13 @@ module Qless
     end
 
     def initialize
-      @replacements = { Dir.pwd => '.' }
+      @replacements = {}
+
+      begin
+        @replacements[Dir.pwd] = '.'
+      rescue Errno::ENOENT
+        # Don't worry if Dir.pwd can't be retrieved.
+      end
       @replacements[ENV['GEM_HOME']] = '<GEM_HOME>' if ENV.key?('GEM_HOME')
     end
 


### PR DESCRIPTION
We're seeing ENOENTs raised when retrieving the current working directory. It's not especially critical to the replacement in error messages, and seeing the actual working directory in errors may help us track down the cause.