### PR TITLE
Fix issue with links getting cleared out after creating a Pivotal ticket

### DIFF
--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -112,20 +112,22 @@
 					<div style="margin-right: 10px">
 						<h3 class="custora-job-data-label"><small>Tags:</small></h3>
 					</div>
-	        <% job.tags.each do |tag| %>
-	        <div class="btn-group custora-job-tags" style="float:left; margin-right: 10px;">
-            <span class="tag" style="line-height: 24px;"><a href="<%= u "/tag/?tag=#{tag}" %>"><%= tag %></a></span>
-				    <button class="btn btn-default custora-remove-button" onclick="untag('<%= job.jid %>', '<%= tag %>')">
-	            <i class="glyphicon glyphicon-remove custora-remove-icon"></i>
-	          </button>
-	        </div>
-					<ul class="custora-job-tag-list">
-						<li>
-							<a href="<%= u "/tag/?tag=#{tag}" %>"><%= tag %></a>
-							<span onclick="untag('<%= job.jid %>', '<%= tag %>')"><i class="glyphicon glyphicon-remove custora-remove-icon"></i></span><%= %>
-						</li>
-					</ul>
-	        <% end %>
+					<div class="custora-job-tags-container">
+						<% job.tags.each do |tag| %>
+						<div class="btn-group custora-job-tags" style="float:left; margin-right: 10px;">
+							<span class="tag" style="line-height: 24px;"><a href="<%= u "/tag/?tag=#{tag}" %>"><%= tag %></a></span>
+							<button class="btn btn-default custora-remove-button" onclick="untag('<%= job.jid %>', '<%= tag %>')">
+								<i class="glyphicon glyphicon-remove custora-remove-icon"></i>
+							</button>
+						</div>
+						<ul class="custora-job-tag-list">
+							<li>
+								<a href="<%= u "/tag/?tag=#{tag}" %>"><%= tag %></a>
+								<span onclick="untag('<%= job.jid %>', '<%= tag %>')"><i class="glyphicon glyphicon-remove custora-remove-icon"></i></span><%= %>
+							</li>
+						</ul>
+						<% end %>
+					</div>
 
 	        <!-- One for adding new tags -->
 	        <div class="btn-group add-tag" style="float:left">

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -297,17 +297,41 @@
         url: '<%= u "/tag" %>',
         data: data,
         success : function() {
-          var div  = $('<div>').attr('class', 'btn-group').attr('style', 'float:left; margin-right: 10px;');
+          /*
+          <div class="btn-group custora-job-tags" style="float:left; margin-right: 10px;">
+            <span class="tag" style="line-height: 24px;"><a href="<!%= u "/tag/?tag=#{tag}" %>"><!%= tag %></a></span>
+				    <button class="btn btn-default custora-remove-button" onclick="untag('<!%= job.jid %>', '<!%= tag %>')">
+	            <i class="glyphicon glyphicon-remove custora-remove-icon"></i>
+	          </button>
+	        </div>
+					<ul class="custora-job-tag-list">
+						<li>
+							<a href="<!%= u "/tag/?tag=#{tag}" %>"><!%= tag %></a>
+							<span onclick="untag('<!%= job.jid %>', '<!%= tag %>')"><i class="glyphicon glyphicon-remove custora-remove-icon"></i></span><!%= %>
+						</li>
+					</ul>
+          */
+          var div  = $('<div>').attr('class', 'btn-group custora-job-tags').attr('style', 'float:left; margin-right: 10px;');
           var span = $('<span>').attr('class', 'tag').attr('style', 'line-height: 24px;');
-          var a = $('a').attr('href', "/tag/?tag=" + tag).text(tag);
-          var btn  = $('<button>').attr('class', 'btn btn-default').click(function() {
+          var a = $('<a>').attr('href', "/tag/?tag=" + tag).text(tag);
+          var btn  = $('<button>').attr('class', 'btn btn-default custora-remove-button').click(function() {
             untag(jid, tag);
           });
-          btn.append($('<i>').attr('class', 'glyphicon glyphicon-remove'));
+          btn.append($('<i>').attr('class', 'glyphicon glyphicon-remove custora-remove-icon'));
           span.append(a);
           div.append(span).append(btn);
+
+          var ul = $('<ul>').attr('class', 'custora-job-tag-list');
+          var li = $('<li>');
+          var untagSpan = $('<span>').click(function() {
+            untag(jid, tag);
+          });
+          untagSpan.append($('<i>').attr('class', 'glyphicon glyphicon-remove custora-remove-icon'));
+          li.append(a.clone()).append(untagSpan);
+          ul.append(li);
+
           $('#job-' + jid.replace('.', '')).find('.add-tag input').val(null)
-          $('#job-' + jid.replace('.', '')).find('.tags').append(div);
+          $('#job-' + jid.replace('.', '')).find('.custora-job-tags-container').append(div).append(ul);
           flash('Tagged ' + jid + ' with ' + tag, 'success', 1500);
         }, error: function() {
           flash('Failed to tag ' + jid + ' with ' + tag);


### PR DESCRIPTION
The success handler in the `tag` call was calling `$('a')`, which selects all links on the page, instead of `$(<a>)`, which creates a new DOM node. This causes a bunch of links on the page which had non-text children to have their contents cleared out.

Also, this updates the generated DOM nodes to match Custora customizations.

Not sure what's going on with the indentation, I think we have a mix of tabs/spaces 😞  It looks fine in my editor though and converting the files to either tabs or spaces creates a larger diff.