### PR TITLE
Add ability to create JIRA tickets from Qless

### DIFF
--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -247,7 +247,7 @@ module Qless
       pivotal_label = ''
 
       failed_jobs = if ['tagged', 'not_tagged'].include?(params[:pt])
-        pivotal_label = params[:pt] == 'tagged' ? "(In Pivotal)" : "(Not In Pivotal)"
+        pivotal_label = params[:pt] == 'tagged' ? "(In JIRA/Pivotal)" : "(Not In JIRA/Pivotal)"
         jobs = failed_jobs_by_type(include_tag: /^pt-/)[params[:pt].to_sym][params[:type]] || []
         {
           "jobs" => jobs,

--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -43,9 +43,14 @@
 	            </ul>
 	          </div>
             <div class="btn-group custora-job-button-group">
-              <% if (pt_tag = (job.tags || []).find { |tag| tag.match(/pt-(.*)/) }).nil? %>
-                <button title="Create Pivotal Story" class="btn btn-info" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
-              <% else %>
+              <% if (pt_tags = (job.tags || []).select { |tag| tag.match?(/pt-(.*)/) }).none? %>
+                <button title="Create JIRA Issue" class="btn btn-info" onclick="confirmation(this, 'Create JIRA Issue?', function() { createJIRAIssue('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
+                <button title="Create Pivotal Story" class="btn btn-default" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
+							<% end %>
+              <% if pt_tags.find { |tag| tag.match(/pt-jira-(.*)/) } %>
+							  <button title="View JIRA Issue" class="btn btn-info" onclick="window.open(window.jira.url + '/browse/<%= $1 %>', '_blank')"><i class="glyphicon glyphicon-new-window"></i></button>
+							<% end %>
+							<% if pt_tags.find { |tag| !tag.match?(/jira/) && tag.match(/pt-(.*)/) } %>
                 <button title="View Pivotal Story" class="btn btn-info" onclick="window.open('https://www.pivotaltracker.com/story/show/<%= $1 %>', '_blank')"><i class="glyphicon glyphicon-new-window"></i></button>
               <% end %>
             </div>

--- a/lib/qless/server/views/_job.erb
+++ b/lib/qless/server/views/_job.erb
@@ -43,7 +43,7 @@
 	            </ul>
 	          </div>
             <div class="btn-group custora-job-button-group">
-              <% if (pt_tags = (job.tags || []).select { |tag| tag.match?(/pt-(.*)/) }).none? %>
+              <% if (pt_tags = (job.tags || []).grep(/pt-(.*)/)).empty? %>
                 <button title="Create JIRA Issue" class="btn btn-info" onclick="confirmation(this, 'Create JIRA Issue?', function() { createJIRAIssue('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
                 <button title="Create Pivotal Story" class="btn btn-default" onclick="confirmation(this, 'Create Pivotal Story?', function() { createPivotalStory('<%= job.jid %>', fade) })"><i class="glyphicon glyphicon-copy"></i></button>
 							<% end %>

--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -83,6 +83,15 @@
     window.pivotalToken = "<%= $PIVOTAL_TOKEN %>";
     window.pivotalProjectId = "<%= $PIVOTAL_PROJECT_ID %>";
 
+    window.jira = {
+      url: "<%= $JIRA_URL %>",
+      appPort: "<%= $APP_PORT %>",
+      project: "<%= $JIRA_PROJECT %>",
+      components: "<%= $JIRA_COMPONENTS %>".split(","),
+      issueType: "<%= $JIRA_ISSUE_TYPE %>",
+      controllerApiToken: "<%= $JIRA_CONTROLLER_API_TOKEN %>"
+    };
+
     /* This is a helper method to display an alert at the top of the page,
      * in a vein similar to that of Ruby's flash */
     var flash = function(message, t, duration) {
@@ -152,6 +161,47 @@
       if (siteIdTag)
         data.labels.push(siteIdTag);
       return data;
+    }
+
+    var createJIRAIssue = function(jid, cb) {
+      var json = JSON.parse($("#job-json-" + jid).text());
+      var storyData = jobToJIRAIssue(json);
+
+      $.ajax({
+        url: `//${window.location.hostname}:${window.jira.appPort}/jira/create`,
+        type: 'POST',
+        contentType: 'application/json',
+        dataType: 'json',
+        data: JSON.stringify(storyData),
+        processData: true,
+        success: function(resp) {
+          flash("Created JIRA Issue", 'success', 1500);
+          window.open(resp.url, '_blank');
+          tag(jid, "pt-jira-" + resp.key, cb);
+        },
+        error: function(resp) {
+          flash('Error creating issue: ' + resp.responseText || resp.responseJSON.error);
+        },
+      });
+    }
+
+    var jobToJIRAIssue = function(job) {
+      var siteIdTag = job.tags.find((tag) => { return tag.substring(0, 5) == "site-" });
+      var siteId = siteIdTag ? siteIdTag.substring(5) : 'Non-site specific';
+
+      var summary = siteId + ": " + (job.history[job.history.length - 1] || {}).group || `${job.klass_name} - Unknown Error`;
+      var description = `${window.location.origin}/qless/jobs/${job.jid}\n\n` +
+        "`" + job.failure.message.substring(0, 15000) + "`"; // keep well under 20k limit on description
+
+      return {
+        project: window.jira.project,
+        issue_type: window.jira.issueType,
+        summary: summary,
+        description: description,
+        component_names: window.jira.components,
+        api_token: window.jira.controllerApiToken,
+        site_id: siteIdTag ? siteId : null,
+      };
     }
 
     /* This is a helper method to move a job into a queue, and then it will


### PR DESCRIPTION
This will hit an endpoint in the Custora app to prevent having to pass credentials to Qless (there is/will be a hardcoded API token in the JiraController to prevent open access though).